### PR TITLE
Assign WASM spec tests its own label.

### DIFF
--- a/generated-tests/CMakeLists.txt
+++ b/generated-tests/CMakeLists.txt
@@ -29,7 +29,7 @@ foreach(TEST_SUITE ${WASM_TESTS}) # create an independent target for each test s
     foreach(SN ${SN_LIST})
       foreach(RUNTIME ${EOSIO_WASM_RUNTIMES})
           add_test(NAME ${SN}_unit_test_${RUNTIME} COMMAND wasm_spec_test --run_test=${SN} --report_level=detailed --color_output --catch_system_errors=no -- --${RUNTIME})
-          set_property(TEST ${SN}_unit_test_${RUNTIME} PROPERTY LABELS long_running_tests)
+          set_property(TEST ${SN}_unit_test_${RUNTIME} PROPERTY LABELS wasm_spec_tests)
           # build list of tests to run during coverage testing
           if(ctest_tests)
               string(APPEND ctest_tests "|")


### PR DESCRIPTION
After discussing this change more, we decided to change the label from `long_running_tests` to `wasm_spec_tests` to ensure WASM spec tests are still running before each PR. New pipeline steps are also in works to support this change.

See:
https://buildkite.com/EOSIO/eosio/builds/18246 | WASM Spec Tests step in action and split from unit tests.