### PR TITLE
update cmake to use wrapped version of chain lib

### DIFF
--- a/generated-tests/CMakeLists.txt
+++ b/generated-tests/CMakeLists.txt
@@ -7,7 +7,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/wasm_spec_tests.hpp.in ${CMAKE_CURREN
 file(GLOB WASM_TESTS "*.cpp") # find all unit test suites
 add_executable( wasm_spec_test ${WASM_TESTS}) # build unit tests as one executable
 
-target_link_libraries( wasm_spec_test eosio_chain chainbase eosio_testing fc appbase ${PLATFORM_SPECIFIC_LIBS} )
+target_link_libraries( wasm_spec_test eosio_chain_wrap chainbase eosio_testing fc appbase ${PLATFORM_SPECIFIC_LIBS} )
 
 target_compile_options(wasm_spec_test PUBLIC -DDISABLE_EOSLIB_SERIALIZE)
 target_include_directories( wasm_spec_test PUBLIC


### PR DESCRIPTION
This is matched up with https://github.com/EOSIO/eos/pull/8924 

It links with the wrapped version of the chain lib rather than the default unwrapped one.