### PR TITLE
Update license year 2021 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 block.one and its contributors.  All rights reserved.
+Copyright (c) 2021 block.one and its contributors.  All rights reserved.
 
 The MIT License
 


### PR DESCRIPTION
Update license of submodule `eosio-wasm-spec-tests` to year 2021 